### PR TITLE
Do not use reverse domain naming for the executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(persistent_touch_id_sudo C)
 
 set(CMAKE_C_STANDARD 17)
 
-add_executable(com.yuriyguts.persistent-touch-id-sudo src/main.c)
+add_executable(persistent-touch-id-sudo src/main.c)
 
-install(TARGETS com.yuriyguts.persistent-touch-id-sudo DESTINATION /usr/local/bin)
+install(TARGETS persistent-touch-id-sudo DESTINATION /usr/local/bin)
 install(FILES assets/com.yuriyguts.persistent-touch-id-sudo.plist DESTINATION /Library/LaunchDaemons)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and persists across OS upgrades.
 
 The project installs two files on your system:
 
-1. Executable: `/usr/local/bin/com.yuriyguts.persistent-touch-id-sudo`
+1. Executable: `/usr/local/bin/persistent-touch-id-sudo`
 2. Launch daemon: `/Library/LaunchDaemons/com.yuriyguts.persistent-touch-id-sudo.plist`
 
 When macOS starts up, it runs the launch daemon, which defines how to run the executable
@@ -35,13 +35,13 @@ $ sudo make install
 ```
 
 Then, go to Preferences > Security & Privacy > Full Disk Access, and add
-the executable `/usr/local/bin/com.yuriyguts.persistent-touch-id-sudo` to the allow list.
+the executable `/usr/local/bin/persistent-touch-id-sudo` to the allow list.
 
 ## Uninstalling
 
 ```shell
 $ sudo rm /Library/LaunchDaemons/com.yuriyguts.persistent-touch-id-sudo.plist
-$ sudo rm /usr/local/bin/com.yuriyguts.persistent-touch-id-sudo
+$ sudo rm /usr/local/bin/persistent-touch-id-sudo
 ```
 
 ## Troubleshooting

--- a/assets/com.yuriyguts.persistent-touch-id-sudo.plist
+++ b/assets/com.yuriyguts.persistent-touch-id-sudo.plist
@@ -12,7 +12,7 @@
     <true/>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/com.yuriyguts.persistent-touch-id-sudo</string>
+        <string>/usr/local/bin/persistent-touch-id-sudo</string>
     </array>
     <key>StandardOutPath</key>
     <string>/tmp/com.yuriyguts.persistent-touch-id-sudo.stdout.log</string>


### PR DESCRIPTION
Evidently, at some point, macOS started having issues with selecting binaries named `com.*` for the Full Disk Access allow list. To work around this, this PR stops using the "reverse domain name" naming pattern for the executable that alters the PAM config.

This should fix #2 .